### PR TITLE
Fixing pip install issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN pip install --upgrade pip
 WORKDIR /app
 COPY $WHEEL_DIR/leanpub_multi_action-$LEANPUB_MULTI_ACTION_VERSION-py3-none-any.whl /app
 
-RUN pip install leanpub_multi_action-$LEANPUB_MULTI_ACTION_VERSION-py3-none-any.whl
+RUN pip install --no-cache-dir leanpub_multi_action-$LEANPUB_MULTI_ACTION_VERSION-py3-none-any.whl
 
 ENTRYPOINT [ "lma" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "leanpub-multi-action"
-version = "0.3.10"
+version = "0.3.11"
 description = "GitHub Actions for Leanpub.com"
 authors = ["Brett Lykins <lykinsbd@gmail.com>"]
 


### PR DESCRIPTION
According to this SO link telling it --no-cache-dir should help:
https://stackoverflow.com/questions/34889056/trying-to-install-pycuda-getting-zip-error/41916324#41916324