### PR TITLE
feat: Add publish action support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,17 @@ inputs:
     description: "Start a Preview job"
     required: false
     default: false
+  publish:
+    description: "Publish the book"
+    required: false
+    default: false
+  email-readers:
+    description: "Email readers about the new publish"
+    required: false
+    default: false
+  release-notes:
+    description: "Release notes for the publish"
+    required: false
 runs:
   using: "docker"
   image: "docker://ghcr.io/lykinsbd/leanpub-multi-action:latest"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -23,13 +23,17 @@ from leanpub_multi_action.leanpub import Leanpub
     ),
 )
 @click.option("--preview", envvar="INPUT_PREVIEW", is_flag=True, help="Preview a book on Leanpub.")
-@click.option("--publish", is_flag=True, help="Publish a book on Leanpub.")
+@click.option("--publish", envvar="INPUT_PUBLISH", is_flag=True, help="Publish a book on Leanpub.")
+@click.option("--email_readers", envvar="INPUT_EMAIL-READERS", is_flag=True, help="Email readers about the new publish.")
+@click.option("--release_notes", envvar="INPUT_RELEASE-NOTES", default=None, help="Release notes for the publish.")
 @click.option("--check_status", is_flag=True, help="Check the job status of a Preview or Publish on Leanpub.")
 def main(
     leanpub_api_key: str = None,
     book_slug: str = None,
     preview: bool = False,
     publish: bool = False,
+    email_readers: bool = False,
+    release_notes: str = None,
     check_status: bool = False,
 ) -> int:
     """Entrypoint into our script.
@@ -89,7 +93,16 @@ def main(
 
     # Check if we are publishing
     if publish:
-        pass  # TODO: build this
+        print(f"Publishing '{book_slug}'")
+        resp, err = leanpub.publish(book_slug=book_slug, email_readers=email_readers, release_notes=release_notes)
+        if err is not None:
+            print(err)
+            exit_code = 1
+        elif resp.status_code == 200:
+            print(f"Publish job started at {datetime.datetime.utcnow()}")
+        else:
+            print("Unknown error has occurred!")
+            exit_code = 1
 
     # Check if we are checking :lulz:
     if check_status:

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -42,3 +42,28 @@ class Leanpub(requests.Session):
             return None, exception
 
         return resp, None
+
+    def publish(
+        self,
+        book_slug: str,
+        email_readers: bool = False,
+        release_notes: Optional[str] = None,
+    ) -> Tuple[Optional[requests.Response], Optional[requests.RequestException]]:
+        """Publish the book_slug provided.
+
+        Args:
+            book_slug (str): book_slug to publish
+            email_readers (bool): Whether to email readers about the new version
+            release_notes (str): Optional release notes for this publish
+        """
+        url = f"{self.leanpub_url}{book_slug}/publish.json"
+        payload = {"api_key": self.leanpub_api_key, "publish[email_readers]": email_readers}
+        if release_notes:
+            payload["publish[release_notes]"] = release_notes
+        try:
+            resp = self.post(url=url, data=payload)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None


### PR DESCRIPTION
Adds support for the Leanpub Publish API endpoint.

## Changes
- Add `publish()` method to `Leanpub` class with `email_readers` and `release_notes` params
- Wire up `--publish`, `--email_readers`, `--release_notes` CLI options
- Add `publish`, `email-readers`, `release-notes` inputs to `action.yml`

## Usage
```yaml
- uses: lykinsbd/leanpub-multi-action@v2
  with:
    leanpub-api-key: ${{ secrets.LEANPUB_API_KEY }}
    leanpub-book-slug: mybook
    publish: true
    email-readers: true
    release-notes: "Bug fixes and improvements"
```

Closes #14