### PR TITLE
feat: Add check status/watch action support

### DIFF
--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -106,7 +106,17 @@ def main(
 
     # Check if we are checking :lulz:
     if check_status:
-        pass  # TODO: make this happen
+        print(f"Checking status of '{book_slug}'")
+        resp, err = leanpub.check_status(book_slug=book_slug)
+        if err is not None:
+            print(err)
+            exit_code = 1
+        elif resp.status_code == 200:
+            status = resp.json()
+            print(f"Status: {status}")
+        else:
+            print("Unknown error has occurred!")
+            exit_code = 1
 
     return exit_code
 

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -67,3 +67,19 @@ class Leanpub(requests.Session):
             return None, exception
 
         return resp, None
+
+    def check_status(self, book_slug: str) -> Tuple[Optional[requests.Response], Optional[requests.RequestException]]:
+        """Check the job status of a Preview or Publish for the book_slug provided.
+
+        Args:
+            book_slug (str): book_slug to check status of
+        """
+        url = f"{self.leanpub_url}{book_slug}/book_status.json"
+        params = {"api_key": self.leanpub_api_key}
+        try:
+            resp = self.get(url=url, params=params)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None


### PR DESCRIPTION
Adds support for checking the status of a Leanpub Preview or Publish job.

## Changes
- Add `check_status()` method to `Leanpub` class — GET to `/{slug}/book_status.json`
- Wire up `--check_status` CLI option to query and print job status

## Usage
```yaml
- uses: lykinsbd/leanpub-multi-action@v2
  with:
    leanpub-api-key: ${{ secrets.LEANPUB_API_KEY }}
    leanpub-book-slug: mybook
    check_status: true
```

Closes #15