### PR TITLE
feat: Add comprehensive unit tests (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -120,12 +120,12 @@ def main(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     if preview:
         print(f"Generating a Preview of '{book_slug}'")
         resp, err = leanpub.preview(book_slug=book_slug)
-        exit_code = _handle_response(resp, err, f"Preview job started at {datetime.datetime.utcnow()}")
+        exit_code = _handle_response(resp, err, f"Preview job started at {datetime.datetime.now(datetime.UTC)}")
 
     if publish:
         print(f"Publishing '{book_slug}'")
         resp, err = leanpub.publish(book_slug=book_slug, email_readers=email_readers, release_notes=release_notes)
-        exit_code = _handle_response(resp, err, f"Publish job started at {datetime.datetime.utcnow()}")
+        exit_code = _handle_response(resp, err, f"Publish job started at {datetime.datetime.now(datetime.UTC)}")
 
     if check_status:
         print(f"Checking status of '{book_slug}'")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -15,74 +15,123 @@ def _invoke(*args):
 
 
 class TestValidation:
+    """Test input validation guards."""
+
     def test_no_api_key(self):
         result = _invoke("--book_slug", SLUG, "--preview")
-        assert result.exit_code == 0  # click exit code
+        assert result.exit_code == 1
         assert "No Leanpub API Key Found!" in result.output
 
     def test_no_book_slug(self):
         result = _invoke("--leanpub_api_key", API_KEY, "--preview")
+        assert result.exit_code == 1
         assert "No Leanpub Book Slug Found!" in result.output
 
     def test_no_action(self):
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG)
+        assert result.exit_code == 1
         assert "Must either Publish, Preview, or Check Status!" in result.output
 
 
 class TestPreviewCLI:
+    """Test the preview action path."""
+
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_success(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.preview.return_value = (mock_resp, None)
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        assert result.exit_code == 0
         assert "Preview job started" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.preview.return_value = (None, Exception("fail"))
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        assert result.exit_code == 1
         assert "fail" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_unknown_error(self, mock_cls):
+        mock_resp = MagicMock(status_code=500)
+        mock_cls.return_value.preview.return_value = (mock_resp, None)
+        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        assert result.exit_code == 1
+        assert "Unknown error has occurred!" in result.output
 
 
 class TestPublishCLI:
+    """Test the publish action path."""
+
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_success(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.publish.return_value = (mock_resp, None)
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        assert result.exit_code == 0
         assert "Publish job started" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.publish.return_value = (None, Exception("denied"))
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        assert result.exit_code == 1
         assert "denied" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_unknown_error(self, mock_cls):
+        mock_resp = MagicMock(status_code=403)
+        mock_cls.return_value.publish.return_value = (mock_resp, None)
+        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        assert result.exit_code == 1
+        assert "Unknown error has occurred!" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_with_options(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.publish.return_value = (mock_resp, None)
         result = _invoke(
-            "--leanpub_api_key", API_KEY, "--book_slug", SLUG,
-            "--publish", "--email_readers", "--release_notes", "v2",
+            "--leanpub_api_key",
+            API_KEY,
+            "--book_slug",
+            SLUG,
+            "--publish",
+            "--email_readers",
+            "--release_notes",
+            "v2",
         )
         mock_cls.return_value.publish.assert_called_once_with(
-            book_slug=SLUG, email_readers=True, release_notes="v2"
+            book_slug=SLUG,
+            email_readers=True,
+            release_notes="v2",
         )
+        assert result.exit_code == 0
         assert "Publish job started" in result.output
 
 
 class TestCheckStatusCLI:
+    """Test the check_status action path."""
+
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_success(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_resp.json.return_value = {"status": "complete"}
         mock_cls.return_value.check_status.return_value = (mock_resp, None)
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        assert result.exit_code == 0
         assert "complete" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.check_status.return_value = (None, Exception("timeout"))
         result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        assert result.exit_code == 1
         assert "timeout" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_unknown_error(self, mock_cls):
+        mock_resp = MagicMock(status_code=500)
+        mock_cls.return_value.check_status.return_value = (mock_resp, None)
+        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        assert result.exit_code == 1
+        assert "Unknown error has occurred!" in result.output

--- a/tests/unit/test_leanpub.py
+++ b/tests/unit/test_leanpub.py
@@ -14,6 +14,8 @@ def _client():
 
 
 class TestPreview:
+    """Test the preview API call."""
+
     def test_success(self):
         client = _client()
         with rm.Mocker() as m:
@@ -21,6 +23,7 @@ class TestPreview:
             resp, err = client.preview(SLUG)
         assert err is None
         assert resp.status_code == 200
+        assert resp.request.body == f'{{"api_key": "{API_KEY}"}}'.encode()
 
     def test_http_error(self):
         client = _client()
@@ -32,6 +35,8 @@ class TestPreview:
 
 
 class TestPublish:
+    """Test the publish API call."""
+
     def test_success(self):
         client = _client()
         with rm.Mocker() as m:
@@ -39,6 +44,8 @@ class TestPublish:
             resp, err = client.publish(SLUG)
         assert err is None
         assert resp.status_code == 200
+        assert f"api_key={API_KEY}" in resp.request.body
+        assert "publish%5Bemail_readers%5D=False" in resp.request.body
 
     def test_with_options(self):
         client = _client()
@@ -46,9 +53,8 @@ class TestPublish:
             m.post(f"https://leanpub.com/{SLUG}/publish.json", status_code=200)
             resp, err = client.publish(SLUG, email_readers=True, release_notes="v2.0")
         assert err is None
-        body = resp.request.body
-        assert "publish%5Bemail_readers%5D=True" in body
-        assert "publish%5Brelease_notes%5D=v2.0" in body
+        assert "publish%5Bemail_readers%5D=True" in resp.request.body
+        assert "publish%5Brelease_notes%5D=v2.0" in resp.request.body
 
     def test_http_error(self):
         client = _client()
@@ -60,13 +66,20 @@ class TestPublish:
 
 
 class TestCheckStatus:
+    """Test the check_status API call."""
+
     def test_success(self):
         client = _client()
         with rm.Mocker() as m:
-            m.get(f"https://leanpub.com/{SLUG}/book_status.json", json={"status": "working"}, status_code=200)
+            m.get(
+                f"https://leanpub.com/{SLUG}/book_status.json",
+                json={"status": "working"},
+                status_code=200,
+            )
             resp, err = client.check_status(SLUG)
         assert err is None
         assert resp.json() == {"status": "working"}
+        assert f"api_key={API_KEY}" in resp.request.url
 
     def test_http_error(self):
         client = _client()


### PR DESCRIPTION
Closes #54

## Unit Tests

### CLI (`test_cli.py`) — 13 tests
- **Validation**: no API key, no book slug, no action selected — all assert exit code 1
- **Preview**: success (exit 0), error (exit 1), unknown error (non-200 response, exit 1)
- **Publish**: success, error, unknown error, with options (verifies `email_readers` and `release_notes` passed through)
- **Check Status**: success (verifies JSON output), error, unknown error

### Leanpub Client (`test_leanpub.py`) — 7 tests
- **Preview**: success (verifies `api_key` in request payload), HTTP error
- **Publish**: success (verifies payload), with options (verifies `email_readers`/`release_notes` in body), HTTP error
- **Check Status**: success (verifies `api_key` in query params, JSON response), HTTP error

### Other fixes
- `datetime.utcnow()` → `datetime.now(datetime.UTC)` (deprecation fix)
- `.vscode/` added to `.gitignore`

21 tests total, pylint 10.00/10, ruff clean.