### PR TITLE
feat: Refactor CLI to Click subcommands (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,60 @@ Recommended to place this in a GitHub Secret named `LEANPUB_API_KEY`.
 **Required** The "slugified" name of your book, i.e. "mygreatbook" for "My Great Book".
 Per Leanpub's [API documentation](https://leanpub.com/help/api), it is "the part of the URL for your book after `https://leanpub.com/"`.
 
-### `preview`
+### `action`
 
-Boolean, set to "true" to trigger a Leanpub Preview generation for your book.
+**Required** The action to perform. One of: `preview`, `publish`, or `check-status`.
+
+### `email-readers`
+
+Boolean, set to `"true"` to email readers about a new publish. Only used with `action: publish`.
+
+### `release-notes`
+
+Release notes for the publish. Only used with `action: publish`.
 
 ## Example Usage
 
 Below is an example workflow file:
 
 ```YAML
-# This is the GH Action file to trigger a preview on push event to a branch named "Preview"
 ---
 name: "Push to Preview"
 
 "on":
   push:
     branches: ["preview"]
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch: null
 
 jobs:
   preview_build:
     runs-on: "ubuntu-latest"
     steps:
-      # Kick off a preview
       - name: "Preview Build"
-        uses: "lykinsbd/leanpub-multi-action@v1.0.2"
+        uses: "lykinsbd/leanpub-multi-action@v2"
         with:
-          leanpub-api-key: "${{secrets.LEANPUB_API_KEY}}"
+          leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
           leanpub-book-slug: "mygreatbook"
-          preview: true
+          action: "preview"
+```
 
+### Publish with release notes
+
+```YAML
+- name: "Publish"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "publish"
+    email-readers: "true"
+    release-notes: "Chapter 5 added"
+```
+
+### CLI Usage
+
+```bash
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,29 +9,18 @@ inputs:
   leanpub-book-slug:
     description: "Leanpub Book Slug"
     required: true
-  preview:
-    description: "Start a Preview job"
-    required: false
-    default: false
-  publish:
-    description: "Publish the book"
-    required: false
-    default: false
+  action:
+    description: "Action to perform: preview, publish, or check-status"
+    required: true
   email-readers:
-    description: "Email readers about the new publish"
+    description: "Email readers about the new publish (publish only)"
     required: false
-    default: false
+    default: "false"
   release-notes:
-    description: "Release notes for the publish"
+    description: "Release notes for the publish (publish only)"
     required: false
-  check-status:
-    description: "Check the job status of a Preview or Publish"
-    required: false
-    default: false
 runs:
   using: "docker"
   image: "docker://ghcr.io/lykinsbd/leanpub-multi-action:latest"
-  # args:
-  #   - "${{ inputs.leanpub-api-key }}"
-  #   - "${{ inputs.leanpub-book-slug }}"
-  #   - "${{ inputs.preview }}"
+  args:
+    - "${{ inputs.action }}"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -35,112 +35,65 @@ def _handle_response(
     return 1
 
 
-@click.command()
+@click.group()
 @click.option(
-    "--leanpub_api_key",
+    "--leanpub-api-key",
     envvar="INPUT_LEANPUB-API-KEY",
-    help="Leanpub API Key. Will also look for 'INPUT_LEANPUB-API-KEY' environment variable.",
+    required=True,
+    help="Leanpub API Key.",
 )
 @click.option(
-    "--book_slug",
+    "--book-slug",
     envvar="INPUT_LEANPUB-BOOK-SLUG",
-    help=(
-        "Book Slug is the unique book name on Leanpub.com (i.e. the 'mybook' portion of https://leanpub.com/mybook)."
-        "Will also look for 'INPUT_LEANPUB-BOOK-SLUG' environment variable."
-    ),
+    required=True,
+    help="Leanpub book slug (the URL path component).",
 )
-@click.option("--preview", envvar="INPUT_PREVIEW", is_flag=True, help="Preview a book on Leanpub.")
-@click.option("--publish", envvar="INPUT_PUBLISH", is_flag=True, help="Publish a book on Leanpub.")
-@click.option(
-    "--email_readers",
-    envvar="INPUT_EMAIL-READERS",
-    is_flag=True,
-    help="Email readers about the new publish.",
-)
-@click.option(
-    "--release_notes",
-    envvar="INPUT_RELEASE-NOTES",
-    default=None,
-    help="Release notes for the publish.",
-)
-@click.option(
-    "--check_status",
-    envvar="INPUT_CHECK-STATUS",
-    is_flag=True,
-    help="Check the job status of a Preview or Publish on Leanpub.",
-)
-def main(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-    leanpub_api_key: str | None = None,
-    book_slug: str | None = None,
-    preview: bool = False,
-    publish: bool = False,
-    email_readers: bool = False,
-    release_notes: str | None = None,
-    check_status: bool = False,
-) -> None:
-    """Entrypoint into our script.
+@click.pass_context
+def main(ctx: click.Context, leanpub_api_key: str, book_slug: str) -> None:
+    """Interact with Leanpub: preview, publish, or check job status."""
+    ctx.ensure_object(dict)
+    ctx.obj["client"] = Leanpub(leanpub_api_key=leanpub_api_key)
+    ctx.obj["book_slug"] = book_slug
 
-    Publish, Preview, or Check Status on an existing Publish/Preview job.
 
-    See #61 for planned refactor to Click subcommands.
+@main.command()
+@click.pass_context
+def preview(ctx: click.Context) -> None:
+    """Generate a preview of the book."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Generating a Preview of '{book_slug}'")
+    resp, err = ctx.obj["client"].preview(book_slug=book_slug)
+    sys.exit(_handle_response(resp, err, f"Preview job started at {datetime.datetime.now(datetime.UTC)}"))
 
-    Args:
-        leanpub_api_key (str): API Key for the Leanpub API.
-            If not set, will error out.
-        book_slug (str): Unique book name from the leanpub URL of the book.
-            i.e. the 'mybook' portion of https://leanpub.com/mybook
-            If not set, will error out.
-        preview (bool): Preview a book on Leanpub.
-        publish (bool): Publish a book on Leanpub.
-        email_readers (bool): Email readers about the new publish.
-        release_notes (str): Release notes for the publish.
-        check_status (bool): Check the job status of a Preview or Publish on Leanpub.
 
-    Returns:
-        int: exit_code as an integer to return to OS
+@main.command()
+@click.option("--email-readers", envvar="INPUT_EMAIL-READERS", is_flag=True, help="Email readers about the publish.")
+@click.option("--release-notes", envvar="INPUT_RELEASE-NOTES", default=None, help="Release notes for the publish.")
+@click.pass_context
+def publish(ctx: click.Context, email_readers: bool, release_notes: str | None) -> None:
+    """Publish the book."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Publishing '{book_slug}'")
+    resp, err = ctx.obj["client"].publish(
+        book_slug=book_slug,
+        email_readers=email_readers,
+        release_notes=release_notes,
+    )
+    sys.exit(_handle_response(resp, err, f"Publish job started at {datetime.datetime.now(datetime.UTC)}"))
 
-    """
-    if not leanpub_api_key:
-        print("No Leanpub API Key Found!")
+
+@main.command(name="check-status")
+@click.pass_context
+def check_status(ctx: click.Context) -> None:
+    """Check the job status of a preview or publish."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Checking status of '{book_slug}'")
+    resp, err = ctx.obj["client"].check_status(book_slug=book_slug)
+    if err is not None:
+        print(err)
         sys.exit(1)
-
-    if not book_slug:
-        print("No Leanpub Book Slug Found!")
-        sys.exit(1)
-
-    print("Leanpub API Key and Book Slug found")
-
-    if not publish and not preview and not check_status:
-        print("Must either Publish, Preview, or Check Status!")
-        sys.exit(1)
-
-    leanpub = Leanpub(leanpub_api_key=leanpub_api_key)
-    exit_code = 0
-
-    if preview:
-        print(f"Generating a Preview of '{book_slug}'")
-        resp, err = leanpub.preview(book_slug=book_slug)
-        exit_code = _handle_response(resp, err, f"Preview job started at {datetime.datetime.now(datetime.UTC)}")
-
-    if publish:
-        print(f"Publishing '{book_slug}'")
-        resp, err = leanpub.publish(book_slug=book_slug, email_readers=email_readers, release_notes=release_notes)
-        exit_code = _handle_response(resp, err, f"Publish job started at {datetime.datetime.now(datetime.UTC)}")
-
-    if check_status:
-        print(f"Checking status of '{book_slug}'")
-        resp, err = leanpub.check_status(book_slug=book_slug)
-        if err is not None:
-            print(err)
-            exit_code = 1
-        elif resp is not None and resp.status_code == 200:
-            print(f"Status: {resp.json()}")
-        else:
-            print("Unknown error has occurred!")
-            exit_code = 1
-
-    sys.exit(exit_code)
-
-
-if __name__ == "__main__":
-    main()
+    if resp is not None and resp.status_code == 200:
+        print(f"Status: {resp.json()}")
+        sys.exit(0)
+    print("Unknown error has occurred!")
+    sys.exit(1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,23 +14,28 @@ def _invoke(*args):
     return CliRunner().invoke(main, list(args))
 
 
+def _base(*args):
+    """Prepend common options and return full arg list."""
+    return ("--leanpub-api-key", API_KEY, "--book-slug", SLUG, *args)
+
+
 class TestValidation:
     """Test input validation guards."""
 
     def test_no_api_key(self):
-        result = _invoke("--book_slug", SLUG, "--preview")
-        assert result.exit_code == 1
-        assert "No Leanpub API Key Found!" in result.output
+        result = _invoke("--book-slug", SLUG, "preview")
+        assert result.exit_code == 2
+        assert "Missing option '--leanpub-api-key'" in result.output
 
     def test_no_book_slug(self):
-        result = _invoke("--leanpub_api_key", API_KEY, "--preview")
-        assert result.exit_code == 1
-        assert "No Leanpub Book Slug Found!" in result.output
+        result = _invoke("--leanpub-api-key", API_KEY, "preview")
+        assert result.exit_code == 2
+        assert "Missing option '--book-slug'" in result.output
 
-    def test_no_action(self):
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG)
-        assert result.exit_code == 1
-        assert "Must either Publish, Preview, or Check Status!" in result.output
+    def test_no_subcommand(self):
+        result = _invoke("--leanpub-api-key", API_KEY, "--book-slug", SLUG)
+        assert result.exit_code == 2
+        assert "Missing command" in result.output
 
 
 class TestPreviewCLI:
@@ -40,14 +45,14 @@ class TestPreviewCLI:
     def test_success(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.preview.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        result = _invoke(*_base("preview"))
         assert result.exit_code == 0
         assert "Preview job started" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.preview.return_value = (None, Exception("fail"))
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        result = _invoke(*_base("preview"))
         assert result.exit_code == 1
         assert "fail" in result.output
 
@@ -55,7 +60,7 @@ class TestPreviewCLI:
     def test_unknown_error(self, mock_cls):
         mock_resp = MagicMock(status_code=500)
         mock_cls.return_value.preview.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--preview")
+        result = _invoke(*_base("preview"))
         assert result.exit_code == 1
         assert "Unknown error has occurred!" in result.output
 
@@ -67,14 +72,14 @@ class TestPublishCLI:
     def test_success(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.publish.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        result = _invoke(*_base("publish"))
         assert result.exit_code == 0
         assert "Publish job started" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.publish.return_value = (None, Exception("denied"))
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        result = _invoke(*_base("publish"))
         assert result.exit_code == 1
         assert "denied" in result.output
 
@@ -82,7 +87,7 @@ class TestPublishCLI:
     def test_unknown_error(self, mock_cls):
         mock_resp = MagicMock(status_code=403)
         mock_cls.return_value.publish.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--publish")
+        result = _invoke(*_base("publish"))
         assert result.exit_code == 1
         assert "Unknown error has occurred!" in result.output
 
@@ -90,16 +95,7 @@ class TestPublishCLI:
     def test_with_options(self, mock_cls):
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.publish.return_value = (mock_resp, None)
-        result = _invoke(
-            "--leanpub_api_key",
-            API_KEY,
-            "--book_slug",
-            SLUG,
-            "--publish",
-            "--email_readers",
-            "--release_notes",
-            "v2",
-        )
+        result = _invoke(*_base("publish", "--email-readers", "--release-notes", "v2"))
         mock_cls.return_value.publish.assert_called_once_with(
             book_slug=SLUG,
             email_readers=True,
@@ -117,14 +113,14 @@ class TestCheckStatusCLI:
         mock_resp = MagicMock(status_code=200)
         mock_resp.json.return_value = {"status": "complete"}
         mock_cls.return_value.check_status.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        result = _invoke(*_base("check-status"))
         assert result.exit_code == 0
         assert "complete" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):
         mock_cls.return_value.check_status.return_value = (None, Exception("timeout"))
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        result = _invoke(*_base("check-status"))
         assert result.exit_code == 1
         assert "timeout" in result.output
 
@@ -132,6 +128,6 @@ class TestCheckStatusCLI:
     def test_unknown_error(self, mock_cls):
         mock_resp = MagicMock(status_code=500)
         mock_cls.return_value.check_status.return_value = (mock_resp, None)
-        result = _invoke("--leanpub_api_key", API_KEY, "--book_slug", SLUG, "--check_status")
+        result = _invoke(*_base("check-status"))
         assert result.exit_code == 1
         assert "Unknown error has occurred!" in result.output


### PR DESCRIPTION
Closes #61

## Breaking Change

The action interface changes from boolean flags to a single `action` input:

```yaml
# Before
with:
  preview: true

# After
with:
  action: preview
```

## Changes

### CLI (`cli.py`)
- `@click.group()` with common options (`--leanpub-api-key`, `--book-slug`) on the group
- Three subcommands: `preview`, `publish`, `check-status`
- `--email-readers` and `--release-notes` scoped to `publish` only
- Eliminates all pylint warnings (too-many-arguments, too-many-branches) naturally
- Removed unnecessary `if __name__` block (entry point defined in pyproject.toml)

### `action.yml`
- Replaced `preview`, `publish`, `check-status` boolean inputs with single `action` input
- Subcommand passed as `args` to Docker entrypoint — no shell wrapper needed

### CLI usage
```bash
lma --leanpub-api-key KEY --book-slug mybook preview
lma --leanpub-api-key KEY --book-slug mybook publish --email-readers --release-notes "v2"
lma --leanpub-api-key KEY --book-slug mybook check-status
```

This sets up cleanly for #18 (subset preview) and #19 (single file preview) as options on the `preview` subcommand.

21 tests, pylint 10.00/10, ruff clean.