### PR TITLE
feat: Add subset and single-file preview (#18, #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,50 @@
-# Leanpub multi-action
+# Leanpub Multi Action
 
-Interact with Leanpub via GitHub Actions
+[![CI](https://github.com/lykinsbd/leanpub-multi-action/actions/workflows/tests.yml/badge.svg?branch=dev)](https://github.com/lykinsbd/leanpub-multi-action/actions/workflows/tests.yml)
+
+A GitHub Action to interact with the [Leanpub API](https://leanpub.com/help/api).
+Preview, publish, and check job status for your Leanpub books — directly from your GitHub workflows.
+
+## Quick Start
+
+```yaml
+- name: "Preview Book"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "preview"
+```
 
 ## Inputs
 
-### `leanpub-api-key`
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `leanpub-api-key` | Yes | — | Leanpub API key (requires a [Pro plan](https://leanpub.com/help/api)). Store as a [GitHub Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). |
+| `leanpub-book-slug` | Yes | — | Book slug — the path component after `https://leanpub.com/`. |
+| `action` | Yes | — | Action to perform: `preview`, `publish`, or `check-status`. |
+| `email-readers` | No | `"false"` | Email readers about a new publish. Only used with `publish`. |
+| `release-notes` | No | — | Release notes for the publish. Only used with `publish`. |
+| `subset` | No | `"false"` | Preview only the files listed in `Subset.txt`. Only used with `preview`. |
+| `single-file` | No | — | Path to a Markdown file for single-file preview. Only used with `preview`. |
 
-**Required** The Leanpub API key for your account, which requires a "Pro" plan on Leanpub.com.
-Recommended to place this in a GitHub Secret named `LEANPUB_API_KEY`.
+## Examples
 
-### `leanpub-book-slug`
+### Full preview on push
 
-**Required** The "slugified" name of your book, i.e. "mygreatbook" for "My Great Book".
-Per Leanpub's [API documentation](https://leanpub.com/help/api), it is "the part of the URL for your book after `https://leanpub.com/"`.
-
-### `action`
-
-**Required** The action to perform. One of: `preview`, `publish`, or `check-status`.
-
-### `email-readers`
-
-Boolean, set to `"true"` to email readers about a new publish. Only used with `action: publish`.
-
-### `release-notes`
-
-Release notes for the publish. Only used with `action: publish`.
-
-## Example Usage
-
-Below is an example workflow file:
-
-```YAML
+```yaml
 ---
-name: "Push to Preview"
+name: "Preview on Push"
 
 "on":
   push:
     branches: ["preview"]
-  workflow_dispatch: null
 
 jobs:
-  preview_build:
+  preview:
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Preview Build"
+      - name: "Preview Book"
         uses: "lykinsbd/leanpub-multi-action@v2"
         with:
           leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
@@ -51,9 +52,40 @@ jobs:
           action: "preview"
 ```
 
+### Subset preview
+
+Preview only the files listed in your book's `Subset.txt`:
+
+```yaml
+- name: "Subset Preview"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "preview"
+    subset: "true"
+```
+
+### Single-file preview
+
+Preview a single Markdown file without modifying `Subset.txt`.
+The output PDF is saved as `{slug}-single-file.pdf` in your Dropbox previews folder.
+
+```yaml
+- name: "Checkout"
+  uses: "actions/checkout@v4"
+- name: "Single File Preview"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "preview"
+    single-file: "manuscript/chapter-05.md"
+```
+
 ### Publish with release notes
 
-```YAML
+```yaml
 - name: "Publish"
   uses: "lykinsbd/leanpub-multi-action@v2"
   with:
@@ -64,10 +96,37 @@ jobs:
     release-notes: "Chapter 5 added"
 ```
 
-### CLI Usage
+### Check job status
+
+```yaml
+- name: "Check Status"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "check-status"
+```
+
+## CLI Usage
+
+The action also ships as a standalone CLI tool called `lma`.
+
+```bash
+pip install leanpub-multi-action
+```
 
 ```bash
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --subset
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --single-file chapter.md
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+## License
+
+[MIT](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,13 @@ inputs:
   release-notes:
     description: "Release notes for the publish (publish only)"
     required: false
+  subset:
+    description: "Preview only the Subset.txt files (preview only)"
+    required: false
+    default: "false"
+  single-file:
+    description: "Path to a Markdown file for single file preview (preview only)"
+    required: false
 runs:
   using: "docker"
   image: "docker://ghcr.io/lykinsbd/leanpub-multi-action:latest"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -1,6 +1,7 @@
 """Leanpub Actions for GitHub Actions Workflows."""
 
 import datetime
+import pathlib
 import sys
 
 import click
@@ -57,13 +58,31 @@ def main(ctx: click.Context, leanpub_api_key: str, book_slug: str) -> None:
 
 
 @main.command()
+@click.option("--subset", envvar="INPUT_SUBSET", is_flag=True, help="Preview only the Subset.txt files.")
+@click.option(
+    "--single-file",
+    envvar="INPUT_SINGLE-FILE",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to a Markdown file to preview.",
+)
 @click.pass_context
-def preview(ctx: click.Context) -> None:
+def preview(ctx: click.Context, subset: bool, single_file: str | None) -> None:
     """Generate a preview of the book."""
     book_slug = ctx.obj["book_slug"]
-    print(f"Generating a Preview of '{book_slug}'")
-    resp, err = ctx.obj["client"].preview(book_slug=book_slug)
-    sys.exit(_handle_response(resp, err, f"Preview job started at {datetime.datetime.now(datetime.UTC)}"))
+    client = ctx.obj["client"]
+    now = datetime.datetime.now(datetime.UTC)
+
+    if single_file:
+        content = pathlib.Path(single_file).read_text(encoding="utf-8")
+        print(f"Generating a Single File Preview of '{book_slug}' from '{single_file}'")
+        resp, err = client.preview_single(book_slug=book_slug, content=content)
+        sys.exit(_handle_response(resp, err, f"Single file preview job started at {now}"))
+
+    kind = "Subset Preview" if subset else "Preview"
+    print(f"Generating a {kind} of '{book_slug}'")
+    resp, err = client.preview(book_slug=book_slug, subset=subset)
+    sys.exit(_handle_response(resp, err, f"{kind} job started at {now}"))
 
 
 @main.command()

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -27,17 +27,46 @@ class Leanpub(requests.Session):
         self.leanpub_api_key = leanpub_api_key
         self.leanpub_url = "https://leanpub.com/"
 
-    def preview(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
+    def preview(
+        self,
+        book_slug: str,
+        subset: bool = False,
+    ) -> tuple[requests.Response | None, requests.RequestException | None]:
         """Request a Preview be built of the book_slug provided.
 
         Args:
             book_slug (str): book_slug to generate a Preview of
+            subset (bool): If True, preview only the Subset.txt files
 
         """
-        url = f"{self.leanpub_url}{book_slug}/preview.json"
+        path = f"{book_slug}/preview/subset.json" if subset else f"{book_slug}/preview.json"
+        url = f"{self.leanpub_url}{path}"
         payload = {"api_key": self.leanpub_api_key}
         try:
             resp = self.post(url=url, json=payload)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None
+
+    def preview_single(
+        self,
+        book_slug: str,
+        content: str,
+    ) -> tuple[requests.Response | None, requests.RequestException | None]:
+        """Preview a single file of Markdown content.
+
+        Args:
+            book_slug (str): book_slug to generate a Preview for
+            content (str): Markdown content to preview
+
+        """
+        url = f"{self.leanpub_url}{book_slug}/preview/single.json"
+        params = {"api_key": self.leanpub_api_key}
+        headers = {"Content-Type": "text/plain"}
+        try:
+            resp = self.post(url=url, params=params, data=content.encode(), headers=headers)
             resp.raise_for_status()
         except requests.RequestException as exception:
             return None, exception

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -46,8 +46,32 @@ class TestPreviewCLI:
         mock_resp = MagicMock(status_code=200)
         mock_cls.return_value.preview.return_value = (mock_resp, None)
         result = _invoke(*_base("preview"))
+        mock_cls.return_value.preview.assert_called_once_with(book_slug=SLUG, subset=False)
         assert result.exit_code == 0
         assert "Preview job started" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_subset(self, mock_cls):
+        mock_resp = MagicMock(status_code=200)
+        mock_cls.return_value.preview.return_value = (mock_resp, None)
+        result = _invoke(*_base("preview", "--subset"))
+        mock_cls.return_value.preview.assert_called_once_with(book_slug=SLUG, subset=True)
+        assert result.exit_code == 0
+        assert "Subset Preview job started" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_single_file(self, mock_cls, tmp_path):
+        md_file = tmp_path / "chapter.md"
+        md_file.write_text("# Test\n\nContent.")
+        mock_resp = MagicMock(status_code=200)
+        mock_cls.return_value.preview_single.return_value = (mock_resp, None)
+        result = _invoke(*_base("preview", "--single-file", str(md_file)))
+        mock_cls.return_value.preview_single.assert_called_once_with(
+            book_slug=SLUG,
+            content="# Test\n\nContent.",
+        )
+        assert result.exit_code == 0
+        assert "Single file preview job started" in result.output
 
     @patch("leanpub_multi_action.cli.Leanpub")
     def test_error(self, mock_cls):

--- a/tests/unit/test_leanpub.py
+++ b/tests/unit/test_leanpub.py
@@ -25,11 +25,43 @@ class TestPreview:
         assert resp.status_code == 200
         assert resp.request.body == f'{{"api_key": "{API_KEY}"}}'.encode()
 
+    def test_subset(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.post(f"https://leanpub.com/{SLUG}/preview/subset.json", status_code=200)
+            resp, err = client.preview(SLUG, subset=True)
+        assert err is None
+        assert resp.status_code == 200
+        assert "subset" in resp.request.url
+
     def test_http_error(self):
         client = _client()
         with rm.Mocker() as m:
             m.post(f"https://leanpub.com/{SLUG}/preview.json", status_code=500)
             resp, err = client.preview(SLUG)
+        assert resp is None
+        assert isinstance(err, requests.RequestException)
+
+
+class TestPreviewSingle:
+    """Test the single file preview API call."""
+
+    def test_success(self):
+        client = _client()
+        content = "# Chapter 1\n\nHello world."
+        with rm.Mocker() as m:
+            m.post(f"https://leanpub.com/{SLUG}/preview/single.json", status_code=200)
+            resp, err = client.preview_single(SLUG, content=content)
+        assert err is None
+        assert resp.status_code == 200
+        assert resp.request.body == content.encode()
+        assert f"api_key={API_KEY}" in resp.request.url
+
+    def test_http_error(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.post(f"https://leanpub.com/{SLUG}/preview/single.json", status_code=500)
+            resp, err = client.preview_single(SLUG, content="test")
         assert resp is None
         assert isinstance(err, requests.RequestException)
 


### PR DESCRIPTION
Closes #18, closes #19

## New Preview Options

### Subset Preview (#18)
`POST /SLUG/preview/subset.json` — previews only the files in `Subset.txt`.

```yaml
- uses: lykinsbd/leanpub-multi-action@v2
  with:
    action: preview
    subset: "true"
```

CLI: `lma --leanpub-api-key KEY --book-slug SLUG preview --subset`

### Single-File Preview (#19)
`POST /SLUG/preview/single.json` with `Content-Type: text/plain` — previews a single Markdown file. Output saved as `{slug}-single-file.pdf` in Dropbox previews.

```yaml
- uses: lykinsbd/leanpub-multi-action@v2
  with:
    action: preview
    single-file: "manuscript/chapter-05.md"
```

CLI: `lma --leanpub-api-key KEY --book-slug SLUG preview --single-file chapter.md`

## Changes

- `leanpub.py`: `preview()` gains `subset` param, new `preview_single()` method
- `cli.py`: `preview` subcommand gains `--subset` flag and `--single-file` option (both with envvars for action.yml)
- `action.yml`: New `subset` and `single-file` inputs
- `README.md`: Full rewrite — badges, inputs table, examples for all actions, CLI install/usage, contributing/license links
- 5 new tests (26 total), pylint 10.00/10, ruff clean