### PR TITLE
fix: Fix release workflow for semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: "softprops/action-gh-release@v1"
         with:
           files: "dist/*"
-          body_path: "RELEASE_NOTES.rst"
+          generate_release_notes: true
   publish_container:
     name: "Publish Container Artifacts"
     runs-on: "ubuntu-latest"
@@ -45,10 +45,9 @@ jobs:
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       - name: "Login to ghcr.io"
         uses: "docker/login-action@v3"
         with:


### PR DESCRIPTION
Fix release workflow failures:
- Replace `RELEASE_NOTES.rst` (doesn't exist) with `generate_release_notes: true`
- Add `type=semver,pattern={{major}}` so `v2.0.0` also tags as `2`
- Remove `type=ref,event=branch/pr` patterns (irrelevant for tag-triggered workflow)