### PR TITLE
feat: PyPI publishing and metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
         run: "echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV"
       - name: "Run uv build"
         run: "uv build"
+      - name: "Publish to PyPI"
+        run: "uv publish"
+        env:
+          UV_PUBLISH_TOKEN: "${{ secrets.PYPI_API_TOKEN }}"
       - name: "Upload binaries to release"
         uses: "softprops/action-gh-release@v1"
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.13-slim
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY leanpub_multi_action/ leanpub_multi_action/
 
 RUN uv sync --frozen --no-dev

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ The output PDF is saved as `{slug}-single-file.pdf` in your Dropbox previews fol
 The action also ships as a standalone CLI tool called `lma`.
 
 ```bash
+uv tool install leanpub-multi-action
+```
+
+or with pip:
+
+```bash
 pip install leanpub-multi-action
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,26 @@
 [project]
 name = "leanpub-multi-action"
-version = "1.0.2"
+version = "2.0.0"
 description = "GitHub Actions for Leanpub.com"
 authors = [{name = "Brett Lykins", email = "lykinsbd@gmail.com"}]
+readme = "README.md"
+license = "MIT"
 requires-python = ">=3.13"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Build Tools",
+]
 dependencies = [
     "requests>=2",
     "click>=8",
 ]
+
+[project.urls]
+Homepage = "https://github.com/lykinsbd/leanpub-multi-action"
+Repository = "https://github.com/lykinsbd/leanpub-multi-action"
+Issues = "https://github.com/lykinsbd/leanpub-multi-action/issues"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "leanpub-multi-action"
-version = "1.0.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Bump version to 2.0.0
- Add `uv publish` to release workflow with `PYPI_API_TOKEN` secret
- Add PyPI metadata (readme, license, classifiers, URLs)
- Copy README.md in Dockerfile for hatchling build
- Add uv as primary CLI install method in README