### PR TITLE
feat: Add book-summary action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Preview, publish, and check job status for your Leanpub books — directly from 
 |------|----------|---------|-------------|
 | `leanpub-api-key` | Yes | — | Leanpub API key (requires a [Pro plan](https://leanpub.com/help/api)). Store as a [GitHub Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). |
 | `leanpub-book-slug` | Yes | — | Book slug — the path component after `https://leanpub.com/`. |
-| `action` | Yes | — | Action to perform: `preview`, `publish`, or `check-status`. |
+| `action` | Yes | — | Action to perform: `preview`, `publish`, `check-status`, or `book-summary`. |
 | `email-readers` | No | `"false"` | Email readers about a new publish. Only used with `publish`. |
 | `release-notes` | No | — | Release notes for the publish. Only used with `publish`. |
 | `subset` | No | `"false"` | Preview only the files listed in `Subset.txt`. Only used with `preview`. |
@@ -107,6 +107,19 @@ The output PDF is saved as `{slug}-single-file.pdf` in your Dropbox previews fol
     action: "check-status"
 ```
 
+### Get book summary
+
+Retrieve book metadata including download URLs, word count, and sales info:
+
+```yaml
+- name: "Book Summary"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "book-summary"
+```
+
 ## CLI Usage
 
 The action also ships as a standalone CLI tool called `lma`.
@@ -127,6 +140,7 @@ lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --subset
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --single-file chapter.md
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-summary
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Leanpub Book Slug"
     required: true
   action:
-    description: "Action to perform: preview, publish, or check-status"
+    description: "Action to perform: preview, publish, check-status, or book-summary"
     required: true
   email-readers:
     description: "Email readers about the new publish (publish only)"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -101,6 +101,23 @@ def publish(ctx: click.Context, email_readers: bool, release_notes: str | None) 
     sys.exit(_handle_response(resp, err, f"Publish job started at {datetime.datetime.now(datetime.UTC)}"))
 
 
+@main.command(name="book-summary")
+@click.pass_context
+def book_summary(ctx: click.Context) -> None:
+    """Get the book summary and metadata."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Getting summary for '{book_slug}'")
+    resp, err = ctx.obj["client"].book_summary(book_slug=book_slug)
+    if err is not None:
+        print(err)
+        sys.exit(1)
+    if resp is not None and resp.status_code == 200:
+        print(resp.json())
+        sys.exit(0)
+    print("Unknown error has occurred!")
+    sys.exit(1)
+
+
 @main.command(name="check-status")
 @click.pass_context
 def check_status(ctx: click.Context) -> None:

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -102,6 +102,23 @@ class Leanpub(requests.Session):
 
         return resp, None
 
+    def book_summary(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
+        """Get the summary/metadata for the book_slug provided.
+
+        Args:
+            book_slug (str): book_slug to get summary of
+
+        """
+        url = f"{self.leanpub_url}{book_slug}.json"
+        params = {"api_key": self.leanpub_api_key}
+        try:
+            resp = self.get(url=url, params=params)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None
+
     def check_status(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
         """Check the job status of a Preview or Publish for the book_slug provided.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -129,6 +129,34 @@ class TestPublishCLI:
         assert "Publish job started" in result.output
 
 
+class TestBookSummaryCLI:
+    """Test the book-summary action path."""
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_success(self, mock_cls):
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"slug": SLUG, "title": "My Book"}
+        mock_cls.return_value.book_summary.return_value = (mock_resp, None)
+        result = _invoke(*_base("book-summary"))
+        assert result.exit_code == 0
+        assert SLUG in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_error(self, mock_cls):
+        mock_cls.return_value.book_summary.return_value = (None, Exception("not found"))
+        result = _invoke(*_base("book-summary"))
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_unknown_error(self, mock_cls):
+        mock_resp = MagicMock(status_code=500)
+        mock_cls.return_value.book_summary.return_value = (mock_resp, None)
+        result = _invoke(*_base("book-summary"))
+        assert result.exit_code == 1
+        assert "Unknown error has occurred!" in result.output
+
+
 class TestCheckStatusCLI:
     """Test the check_status action path."""
 

--- a/tests/unit/test_leanpub.py
+++ b/tests/unit/test_leanpub.py
@@ -97,6 +97,31 @@ class TestPublish:
         assert isinstance(err, requests.RequestException)
 
 
+class TestBookSummary:
+    """Test the book_summary API call."""
+
+    def test_success(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.get(
+                f"https://leanpub.com/{SLUG}.json",
+                json={"slug": SLUG, "title": "My Book", "total_copies_sold": 42},
+                status_code=200,
+            )
+            resp, err = client.book_summary(SLUG)
+        assert err is None
+        assert resp.json()["slug"] == SLUG
+        assert f"api_key={API_KEY}" in resp.request.url
+
+    def test_http_error(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.get(f"https://leanpub.com/{SLUG}.json", status_code=404)
+            resp, err = client.book_summary(SLUG)
+        assert resp is None
+        assert isinstance(err, requests.RequestException)
+
+
 class TestCheckStatus:
     """Test the check_status API call."""
 


### PR DESCRIPTION
Closes #76

- `book_summary()` client method — `GET /{slug}.json`
- `book-summary` CLI subcommand
- 5 new tests (33 total)
- action.yml and README updated