### PR TITLE
feat: Add book-exists action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Preview, publish, and check job status for your Leanpub books — directly from 
 |------|----------|---------|-------------|
 | `leanpub-api-key` | Yes | — | Leanpub API key (requires a [Pro plan](https://leanpub.com/help/api)). Store as a [GitHub Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). |
 | `leanpub-book-slug` | Yes | — | Book slug — the path component after `https://leanpub.com/`. |
-| `action` | Yes | — | Action to perform: `preview`, `publish`, `check-status`, or `book-summary`. |
+| `action` | Yes | — | Action to perform: `preview`, `publish`, `check-status`, `book-summary`, or `book-exists`. |
 | `email-readers` | No | `"false"` | Email readers about a new publish. Only used with `publish`. |
 | `release-notes` | No | — | Release notes for the publish. Only used with `publish`. |
 | `subset` | No | `"false"` | Preview only the files listed in `Subset.txt`. Only used with `preview`. |
@@ -120,6 +120,17 @@ Retrieve book metadata including download URLs, word count, and sales info:
     action: "book-summary"
 ```
 
+### Check if book exists
+
+```yaml
+- name: "Book Exists"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "book-exists"
+```
+
 ## CLI Usage
 
 The action also ships as a standalone CLI tool called `lma`.
@@ -141,6 +152,7 @@ lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --single-file cha
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-summary
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-exists
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Leanpub Book Slug"
     required: true
   action:
-    description: "Action to perform: preview, publish, check-status, or book-summary"
+    description: "Action to perform: preview, publish, check-status, book-summary, or book-exists"
     required: true
   email-readers:
     description: "Email readers about the new publish (publish only)"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -118,6 +118,23 @@ def book_summary(ctx: click.Context) -> None:
     sys.exit(1)
 
 
+@main.command(name="book-exists")
+@click.pass_context
+def book_exists(ctx: click.Context) -> None:
+    """Check if a book exists and get its state."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Checking if '{book_slug}' exists")
+    resp, err = ctx.obj["client"].book_exists(book_slug=book_slug)
+    if err is not None:
+        print(err)
+        sys.exit(1)
+    if resp is not None and resp.status_code == 200:
+        print(resp.json())
+        sys.exit(0)
+    print("Unknown error has occurred!")
+    sys.exit(1)
+
+
 @main.command(name="check-status")
 @click.pass_context
 def check_status(ctx: click.Context) -> None:

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -119,6 +119,23 @@ class Leanpub(requests.Session):
 
         return resp, None
 
+    def book_exists(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
+        """Check if a book exists and get its state.
+
+        Args:
+            book_slug (str): book_slug to check
+
+        """
+        url = f"{self.leanpub_url}{book_slug}/exists.json"
+        params = {"api_key": self.leanpub_api_key}
+        try:
+            resp = self.get(url=url, params=params)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None
+
     def check_status(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
         """Check the job status of a Preview or Publish for the book_slug provided.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -157,6 +157,34 @@ class TestBookSummaryCLI:
         assert "Unknown error has occurred!" in result.output
 
 
+class TestBookExistsCLI:
+    """Test the book-exists action path."""
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_exists(self, mock_cls):
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"exists": True, "state": "published"}
+        mock_cls.return_value.book_exists.return_value = (mock_resp, None)
+        result = _invoke(*_base("book-exists"))
+        assert result.exit_code == 0
+        assert "True" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_error(self, mock_cls):
+        mock_cls.return_value.book_exists.return_value = (None, Exception("unauthorized"))
+        result = _invoke(*_base("book-exists"))
+        assert result.exit_code == 1
+        assert "unauthorized" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_unknown_error(self, mock_cls):
+        mock_resp = MagicMock(status_code=500)
+        mock_cls.return_value.book_exists.return_value = (mock_resp, None)
+        result = _invoke(*_base("book-exists"))
+        assert result.exit_code == 1
+        assert "Unknown error has occurred!" in result.output
+
+
 class TestCheckStatusCLI:
     """Test the check_status action path."""
 

--- a/tests/unit/test_leanpub.py
+++ b/tests/unit/test_leanpub.py
@@ -122,6 +122,43 @@ class TestBookSummary:
         assert isinstance(err, requests.RequestException)
 
 
+class TestBookExists:
+    """Test the book_exists API call."""
+
+    def test_exists(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.get(
+                f"https://leanpub.com/{SLUG}/exists.json",
+                json={"exists": True, "state": "published"},
+                status_code=200,
+            )
+            resp, err = client.book_exists(SLUG)
+        assert err is None
+        assert resp.json()["exists"] is True
+        assert f"api_key={API_KEY}" in resp.request.url
+
+    def test_not_exists(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.get(
+                f"https://leanpub.com/{SLUG}/exists.json",
+                json={"exists": False},
+                status_code=200,
+            )
+            resp, err = client.book_exists(SLUG)
+        assert err is None
+        assert resp.json()["exists"] is False
+
+    def test_http_error(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.get(f"https://leanpub.com/{SLUG}/exists.json", status_code=401)
+            resp, err = client.book_exists(SLUG)
+        assert resp is None
+        assert isinstance(err, requests.RequestException)
+
+
 class TestCheckStatus:
     """Test the check_status API call."""
 


### PR DESCRIPTION
Closes #77

- `book_exists()` client method — `GET /{slug}/exists.json`
- `book-exists` CLI subcommand
- 6 new tests (34 total)
- action.yml and README updated