### PR TITLE
feat: Add unpublish action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Preview, publish, and check job status for your Leanpub books — directly from 
 |------|----------|---------|-------------|
 | `leanpub-api-key` | Yes | — | Leanpub API key (requires a [Pro plan](https://leanpub.com/help/api)). Store as a [GitHub Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). |
 | `leanpub-book-slug` | Yes | — | Book slug — the path component after `https://leanpub.com/`. |
-| `action` | Yes | — | Action to perform: `preview`, `publish`, `check-status`, `book-summary`, or `book-exists`. |
+| `action` | Yes | — | Action to perform: `preview`, `publish`, `unpublish`, `check-status`, `book-summary`, or `book-exists`. |
 | `email-readers` | No | `"false"` | Email readers about a new publish. Only used with `publish`. |
 | `release-notes` | No | — | Release notes for the publish. Only used with `publish`. |
 | `subset` | No | `"false"` | Preview only the files listed in `Subset.txt`. Only used with `preview`. |
@@ -96,6 +96,17 @@ The output PDF is saved as `{slug}-single-file.pdf` in your Dropbox previews fol
     release-notes: "Chapter 5 added"
 ```
 
+### Unpublish
+
+```yaml
+- name: "Unpublish"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "unpublish"
+```
+
 ### Check job status
 
 ```yaml
@@ -150,6 +161,7 @@ lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --subset
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --single-file chapter.md
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook unpublish
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-summary
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-exists

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Leanpub Book Slug"
     required: true
   action:
-    description: "Action to perform: preview, publish, check-status, book-summary, or book-exists"
+    description: "Action to perform: preview, publish, unpublish, check-status, book-summary, or book-exists"
     required: true
   email-readers:
     description: "Email readers about the new publish (publish only)"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -135,6 +135,16 @@ def book_exists(ctx: click.Context) -> None:
     sys.exit(1)
 
 
+@main.command()
+@click.pass_context
+def unpublish(ctx: click.Context) -> None:
+    """Unpublish the book."""
+    book_slug = ctx.obj["book_slug"]
+    print(f"Unpublishing '{book_slug}'")
+    resp, err = ctx.obj["client"].unpublish(book_slug=book_slug)
+    sys.exit(_handle_response(resp, err, f"Unpublish completed at {datetime.datetime.now(datetime.UTC)}"))
+
+
 @main.command(name="check-status")
 @click.pass_context
 def check_status(ctx: click.Context) -> None:

--- a/leanpub_multi_action/leanpub.py
+++ b/leanpub_multi_action/leanpub.py
@@ -136,6 +136,23 @@ class Leanpub(requests.Session):
 
         return resp, None
 
+    def unpublish(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
+        """Unpublish the book.
+
+        Args:
+            book_slug (str): book_slug to unpublish
+
+        """
+        url = f"{self.leanpub_url}{book_slug}/unpublish.json"
+        data = {"api_key": self.leanpub_api_key}
+        try:
+            resp = self.post(url=url, data=data)
+            resp.raise_for_status()
+        except requests.RequestException as exception:
+            return None, exception
+
+        return resp, None
+
     def check_status(self, book_slug: str) -> tuple[requests.Response | None, requests.RequestException | None]:
         """Check the job status of a Preview or Publish for the book_slug provided.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -185,6 +185,25 @@ class TestBookExistsCLI:
         assert "Unknown error has occurred!" in result.output
 
 
+class TestUnpublishCLI:
+    """Test the unpublish action path."""
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_success(self, mock_cls):
+        mock_resp = MagicMock(status_code=200)
+        mock_cls.return_value.unpublish.return_value = (mock_resp, None)
+        result = _invoke(*_base("unpublish"))
+        assert result.exit_code == 0
+        assert "Unpublish completed at" in result.output
+
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_error(self, mock_cls):
+        mock_cls.return_value.unpublish.return_value = (None, Exception("forbidden"))
+        result = _invoke(*_base("unpublish"))
+        assert result.exit_code == 1
+        assert "forbidden" in result.output
+
+
 class TestCheckStatusCLI:
     """Test the check_status action path."""
 

--- a/tests/unit/test_leanpub.py
+++ b/tests/unit/test_leanpub.py
@@ -159,6 +159,27 @@ class TestBookExists:
         assert isinstance(err, requests.RequestException)
 
 
+class TestUnpublish:
+    """Test the unpublish API call."""
+
+    def test_success(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.post(f"https://leanpub.com/{SLUG}/unpublish.json", status_code=200)
+            resp, err = client.unpublish(SLUG)
+        assert err is None
+        assert resp.status_code == 200
+        assert f"api_key={API_KEY}" in resp.request.body
+
+    def test_http_error(self):
+        client = _client()
+        with rm.Mocker() as m:
+            m.post(f"https://leanpub.com/{SLUG}/unpublish.json", status_code=403)
+            resp, err = client.unpublish(SLUG)
+        assert resp is None
+        assert isinstance(err, requests.RequestException)
+
+
 class TestCheckStatus:
     """Test the check_status API call."""
 


### PR DESCRIPTION
Closes #78

- `unpublish()` client method — `POST /{slug}/unpublish.json`
- `unpublish` CLI subcommand
- 5 new tests (33 total on this branch)
- action.yml and README updated