### PR TITLE
feat: Add --wait polling to check-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Preview, publish, and check job status for your Leanpub books — directly from 
 | `release-notes` | No | — | Release notes for the publish. Only used with `publish`. |
 | `subset` | No | `"false"` | Preview only the files listed in `Subset.txt`. Only used with `preview`. |
 | `single-file` | No | — | Path to a Markdown file for single-file preview. Only used with `preview`. |
+| `wait` | No | `"false"` | Poll until job completes. Only used with `check-status`. |
+| `poll-interval` | No | `"5"` | Seconds between polls. Only used with `check-status --wait`. |
+| `timeout` | No | `"120"` | Max seconds to wait. Only used with `check-status --wait`. |
 
 ## Examples
 
@@ -118,6 +121,20 @@ The output PDF is saved as `{slug}-single-file.pdf` in your Dropbox previews fol
     action: "check-status"
 ```
 
+### Poll until job completes
+
+```yaml
+- name: "Wait for Preview"
+  uses: "lykinsbd/leanpub-multi-action@v2"
+  with:
+    leanpub-api-key: "${{ secrets.LEANPUB_API_KEY }}"
+    leanpub-book-slug: "mygreatbook"
+    action: "check-status"
+    wait: "true"
+    poll-interval: "10"
+    timeout: "300"
+```
+
 ### Get book summary
 
 Retrieve book metadata including download URLs, word count, and sales info:
@@ -163,6 +180,7 @@ lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook preview --single-file cha
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook publish --email-readers --release-notes "v2"
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook unpublish
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status
+lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook check-status --wait --timeout 300
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-summary
 lma --leanpub-api-key YOUR_KEY --book-slug mygreatbook book-exists
 ```

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,18 @@ inputs:
   single-file:
     description: "Path to a Markdown file for single file preview (preview only)"
     required: false
+  wait:
+    description: "Poll until job completes (check-status only)"
+    required: false
+    default: "false"
+  poll-interval:
+    description: "Seconds between polls (check-status --wait only)"
+    required: false
+    default: "5"
+  timeout:
+    description: "Max seconds to wait (check-status --wait only)"
+    required: false
+    default: "120"
 runs:
   using: "docker"
   image: "docker://ghcr.io/lykinsbd/leanpub-multi-action:latest"

--- a/leanpub_multi_action/cli.py
+++ b/leanpub_multi_action/cli.py
@@ -3,6 +3,7 @@
 import datetime
 import pathlib
 import sys
+import time
 
 import click
 import requests
@@ -146,17 +147,37 @@ def unpublish(ctx: click.Context) -> None:
 
 
 @main.command(name="check-status")
+@click.option("--wait", is_flag=True, default=False, envvar="INPUT_WAIT", help="Poll until job completes.")
+@click.option("--poll-interval", default=5, type=int, envvar="INPUT_POLL_INTERVAL", help="Seconds between polls.")
+@click.option("--timeout", default=120, type=int, envvar="INPUT_TIMEOUT", help="Max seconds to wait.")
 @click.pass_context
-def check_status(ctx: click.Context) -> None:
+def check_status(ctx: click.Context, wait: bool, poll_interval: int, timeout: int) -> None:
     """Check the job status of a preview or publish."""
     book_slug = ctx.obj["book_slug"]
+    client = ctx.obj["client"]
     print(f"Checking status of '{book_slug}'")
-    resp, err = ctx.obj["client"].check_status(book_slug=book_slug)
-    if err is not None:
-        print(err)
+
+    if not wait:
+        resp, err = client.check_status(book_slug=book_slug)
+        if err is not None:
+            print(err)
+            sys.exit(1)
+        if resp is not None and resp.status_code == 200:
+            print(f"Status: {resp.json()}")
+            sys.exit(0)
+        print("Unknown error has occurred!")
         sys.exit(1)
-    if resp is not None and resp.status_code == 200:
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp, err = client.check_status(book_slug=book_slug)
+        if err is not None:
+            print(err)
+            sys.exit(1)
+        if resp is not None and resp.json() == {}:
+            print("Job complete.")
+            sys.exit(0)
         print(f"Status: {resp.json()}")
-        sys.exit(0)
-    print("Unknown error has occurred!")
+        time.sleep(poll_interval)
+    print(f"Timeout after {timeout}s")
     sys.exit(1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -238,3 +238,38 @@ class TestCheckStatusCLI:
         result = _invoke(*_base("check-status"))
         assert result.exit_code == 1
         assert "Unknown error has occurred!" in result.output
+
+
+class TestCheckStatusWaitCLI:
+    """Test the check-status --wait polling."""
+
+    @patch("leanpub_multi_action.cli.time")
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_wait_completes(self, mock_cls, mock_time):
+        mock_time.monotonic = MagicMock(side_effect=[0, 1, 2])
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {}
+        mock_cls.return_value.check_status.return_value = (mock_resp, None)
+        result = _invoke(*_base("check-status"), "--wait", "--timeout", "10")
+        assert result.exit_code == 0
+        assert "Job complete." in result.output
+
+    @patch("leanpub_multi_action.cli.time")
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_wait_timeout(self, mock_cls, mock_time):
+        mock_time.monotonic = MagicMock(side_effect=[0, 200])
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"status": "working"}
+        mock_cls.return_value.check_status.return_value = (mock_resp, None)
+        result = _invoke(*_base("check-status"), "--wait", "--timeout", "10")
+        assert result.exit_code == 1
+        assert "Timeout" in result.output
+
+    @patch("leanpub_multi_action.cli.time")
+    @patch("leanpub_multi_action.cli.Leanpub")
+    def test_wait_error(self, mock_cls, mock_time):
+        mock_time.monotonic = MagicMock(side_effect=[0, 1])
+        mock_cls.return_value.check_status.return_value = (None, Exception("network error"))
+        result = _invoke(*_base("check-status"), "--wait", "--timeout", "10")
+        assert result.exit_code == 1
+        assert "network error" in result.output


### PR DESCRIPTION
Closes #79

- `--wait` flag polls `job_status.json` until `{}` (job complete) or timeout
- `--poll-interval` (default 5s) and `--timeout` (default 120s) options
- 3 new tests: wait completes, timeout, error during wait
- action.yml inputs: `wait`, `poll-interval`, `timeout`
- README updated with polling example and CLI usage